### PR TITLE
polish(prettify outout) prettify output to show env in a table

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -47,6 +47,17 @@ const args = yargs // eslint-disable-line
         handler(argv) {
         }
     })
+    .command('getChildrenData [path]', 'get zknode children detail', {
+        builder(yargs) {
+            return yargs
+                .positional('path', {
+                    describe: 'it\' the path which zknode\'s children you want to query'
+                })
+                .describe('depth', 'depth')
+        },
+        handler(argv) {
+        }
+    })
     .command('mkdirp [path] [data]', 'mkdirp zkpath', {
         builder(yargs) {
             return yargs

--- a/lib/core/command.js
+++ b/lib/core/command.js
@@ -93,6 +93,24 @@ class Command {
       }
   }
 
+  async getChildrenData() {
+    const registry = this._getActiveRegistry();
+    let { path, depth } = this.args;
+    const zk = new ZookeeperManager({
+        registry
+    });
+
+    path = path.replace(/[^^]\/$/, '');
+
+    try {
+        await zk.ready();
+        await zk.getChildrenData(path, {depth});
+    } catch(e) {
+        console.error(e);
+        zk.exit(1);
+    }
+}
+
   async mkdirp() {
     const registry = this._getActiveRegistry();
     let { path } = this.args;

--- a/lib/core/zookeeper-manager.js
+++ b/lib/core/zookeeper-manager.js
@@ -119,6 +119,28 @@ class ZookeeperManager extends Base {
         this.exit();
     }
 
+    async getChildrenData(path, options) {
+        const nodes = await this._getChildren(this.client, path, {}, options);
+        let res = await Promise.all(Object.keys(nodes).map(async (node) => {
+            let data = {}
+            const nodeData = JSON.parse(await zookeeperTools.getData(this.client, posix.join(path, node)))
+            data.id = nodeData.id
+            data.name = nodeData.name
+            data.env = nodeData.metadata && nodeData.metadata.env || ''
+            data.stable_env = nodeData.metadata && nodeData.metadata.stable_env || ''
+            return data
+        }))
+
+        res = res && res.length && res.sort((a, b) => {
+            if(a.env < b.env) return -1
+            return 1
+        })
+
+        // 需要node 10.0.0 以上
+        console.table(res)
+        this.exit()
+    }
+
     async mkdirp(path, buffer) {
         await zookeeperTools.mkdirp(this.client, path, buffer);
         logger.info(`${path} is created`);


### PR DESCRIPTION
节点很多的情况下，需要快速的查到某个环境注册了哪些节点，如查到stable_masterjd注册了那些节点。增加了一个getChildrenData的命令。显示如下：
![wx20181225-204840](https://user-images.githubusercontent.com/7566686/50422602-929e5280-0886-11e9-8b40-b75fe1795368.png)

